### PR TITLE
updated dependency version in finish example to reflect launch version

### DIFF
--- a/examples/finish/package-lock.json
+++ b/examples/finish/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@cedar-policy/authorization-for-expressjs": "file:../Cedar-ExpressJS",
+        "@cedar-policy/authorization-for-expressjs": "^0.1.0",
         "body-parser": "^2.2.0",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",

--- a/examples/finish/package.json
+++ b/examples/finish/package.json
@@ -16,7 +16,7 @@
   "license": "ISC",
   "description": "A simple Express.js API for a pet store",
   "dependencies": {
-    "@cedar-policy/authorization-for-expressjs": "^1.0.0",
+    "@cedar-policy/authorization-for-expressjs": "^0.1.0",
     "body-parser": "^2.2.0",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",


### PR DESCRIPTION
*Description of changes:* `@cedar-policy/authorization-for-expressjs` is launching with version 0.1.0; updated the version in the `finish` application to correctly reflect this. 


