### PR TITLE
add graceful error handling for when fetching the entities or resource fails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,8 @@
       }
     },
     "../cedar-authorization": {
+      "name": "@cedar-policy/cedar-authorization",
       "version": "0.1.0",
-      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@cedar-policy/cedar-wasm": "4.4.0",
@@ -50,7 +50,7 @@
         "ts-node": "^10.9.2",
         "tsup": "^8.4.0",
         "typescript": "^5.8.3",
-        "vitest": "^3.1.4"
+        "vitest": "^1.3.1"
       }
     },
     "../Cedar-Authorization": {

--- a/tests/unit/errorHandling.test.ts
+++ b/tests/unit/errorHandling.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+import { CedarInlineAuthorizationEngine, ExpressAuthorizationMiddleware } from "../../src";
+import fs from 'fs';
+import path from 'path';
+import { StringifiedSchema } from "@cedar-policy/cedar-authorization";
+import express from 'express';
+
+const schema: StringifiedSchema = {
+    type: 'jsonString',
+    schema: fs.readFileSync(path.join(__dirname, 'v4.cedarschema.json'), 'utf8'),
+};
+
+const cedarAuthorizationEngine = new CedarInlineAuthorizationEngine({
+    schema,
+    staticPolicies: 'permit(principal,action,resource);',
+});
+
+
+describe('error Handling tests for handler-specific middleware', () => {
+    it('should handle errors in fetching the resource gracefully', async () => {
+        const expressAuthorization = new ExpressAuthorizationMiddleware({
+            schema,
+            authorizationEngine: cedarAuthorizationEngine,
+            principalConfiguration: {
+                type: 'custom',
+                getPrincipalEntity: async (req) => {
+                    return {
+                        uid: {
+                            type: "NotebooksApp::User",
+                            id: "Alice"
+                        },
+                        attrs: {},
+                        parents: []
+                    };
+                },
+            },
+            skippedEndpoints: [
+                { httpVerb: 'get', path: '/login' },
+                { httpVerb: 'get', path: '/api-spec/v3' },
+                { httpVerb: 'get', path: '/notebooks/:id' },
+                { httpVerb: 'put', path: '/notebooks/:id' },
+                { httpVerb: 'delete', path: '/notebooks/:id' },
+            ],
+            logger: {
+                debug: s => console.log(s),
+                log: s => console.log(s),
+            }
+        });
+        
+        
+        const app = express();
+        app.use(express.json());
+        app.use(expressAuthorization.middleware);
+
+        app.get(
+            '/notebooks/:id',
+            expressAuthorization.handlerSpecificMiddleware({
+                resourceProvider: async req => {
+                    throw new Error('Error fetching resource');
+                }
+            }),
+            (req, res) => {
+                res.send('Hello World!');
+            }
+        );
+
+        await new Promise(resolve => {
+            app.listen(8080, () => {
+                console.log('Server listening...');
+                resolve(true);
+            });
+        });
+
+        const result = await fetch('http://localhost:8080/notebooks/123');
+        expect(result.status).toBe(400);
+    });
+
+    it('should handle errors in fetching the entities gracefully', async () => {
+        const expressAuthorization = new ExpressAuthorizationMiddleware({
+            schema,
+            authorizationEngine: cedarAuthorizationEngine,
+            principalConfiguration: {
+                type: 'custom',
+                getPrincipalEntity: async (req) => {
+                    return {
+                        uid: {
+                            type: "NotebooksApp::User",
+                            id: "Alice"
+                        },
+                        attrs: {},
+                        parents: []
+                    };
+                },
+            },
+            skippedEndpoints: [
+                { httpVerb: 'get', path: '/login' },
+                { httpVerb: 'get', path: '/api-spec/v3' },
+                { httpVerb: 'get', path: '/notebooks/:id' },
+                { httpVerb: 'put', path: '/notebooks/:id' },
+                { httpVerb: 'delete', path: '/notebooks/:id' },
+            ],
+            logger: {
+                debug: s => console.log(s),
+                log: s => console.log(s),
+            }
+        });
+        
+        
+        const app = express();
+        app.use(express.json());
+        app.use(expressAuthorization.middleware);
+
+        app.get(
+            '/notebooks/:id',
+            expressAuthorization.handlerSpecificMiddleware({
+                resourceProvider: async req => {
+                    return {
+                        uid: {
+                            type: "NotebooksApp::Notebook",
+                            id: "123"
+                        },
+                        attrs: {},
+                        parents: []
+                    };
+                },
+                entitiesProvider: async req => {
+                    throw new Error('Error fetching entities');
+                }
+            }),
+            (req, res) => {
+                res.send('Hello World!');
+            }
+        );
+
+        await new Promise(resolve => {
+            app.listen(8080, () => {
+                console.log('Server listening...');
+                resolve(true);
+            });
+        });
+
+        const result = await fetch('http://localhost:8080/notebooks/123');
+        expect(result.status).toBe(400);
+    });
+});

--- a/tests/unit/v4.cedarschema.json
+++ b/tests/unit/v4.cedarschema.json
@@ -1,0 +1,168 @@
+{
+  "NotebooksApp": {
+    "entityTypes": {
+      "User": {
+        "shape": {
+          "attributes": {},
+          "type": "Record"
+        },
+        "memberOfTypes": [
+          "UserGroup"
+        ]
+      },
+      "UserGroup": {
+        "shape": {
+          "attributes": {},
+          "type": "Record"
+        }
+      },
+      "Application": {
+        "shape": {
+          "attributes": {},
+          "type": "Record"
+        }
+      },
+      "Notebook": {
+        "shape": {
+          "type": "Notebook"
+        },
+        "memberOfTypes": []
+      }
+    },
+    "actions": {
+      "get /notebooks": {
+        "appliesTo": {
+          "context": {
+            "type": "Record",
+            "attributes": {}
+          },
+          "principalTypes": [
+            "User"
+          ],
+          "resourceTypes": [
+            "Application"
+          ]
+        },
+        "annotations": {
+          "httpVerb": "get",
+          "httpPathTemplate": "/notebooks"
+        }
+      },
+      "post /notebooks": {
+        "appliesTo": {
+          "context": {
+            "type": "Record",
+            "attributes": {}
+          },
+          "principalTypes": [
+            "User"
+          ],
+          "resourceTypes": [
+            "Application"
+          ]
+        },
+        "annotations": {
+          "httpVerb": "post",
+          "httpPathTemplate": "/notebooks"
+        }
+      },
+      "getNotebookById": {
+        "appliesTo": {
+          "context": {
+            "type": "Record",
+            "attributes": {}
+          },
+          "principalTypes": [
+            "User"
+          ],
+          "resourceTypes": [
+            "Notebook"
+          ]
+        },
+        "annotations": {
+          "httpVerb": "get",
+          "httpPathTemplate": "/notebooks/{id}"
+        }
+      },
+      "putNotebook": {
+        "appliesTo": {
+          "context": {
+            "type": "Record",
+            "attributes": {}
+          },
+          "principalTypes": [
+            "User"
+          ],
+          "resourceTypes": [
+            "Notebook"
+          ]
+        },
+        "annotations": {
+          "httpVerb": "put",
+          "httpPathTemplate": "/notebooks/{id}"
+        }
+      },
+      "deleteNotebook": {
+        "appliesTo": {
+          "context": {
+            "type": "Record",
+            "attributes": {}
+          },
+          "principalTypes": [
+            "User"
+          ],
+          "resourceTypes": [
+            "Notebook"
+          ]
+        },
+        "annotations": {
+          "httpVerb": "delete",
+          "httpPathTemplate": "/notebooks/{id}"
+        }
+      },
+      "get /notebooks/shared-with-me": {
+        "appliesTo": {
+          "context": {
+            "type": "Record",
+            "attributes": {}
+          },
+          "principalTypes": [
+            "User"
+          ],
+          "resourceTypes": [
+            "Application"
+          ]
+        },
+        "annotations": {
+          "httpVerb": "get",
+          "httpPathTemplate": "/notebooks/shared-with-me"
+        }
+      }
+    },
+    "annotations": {
+      "mappingType": "SimpleRest"
+    },
+    "commonTypes": {
+      "Notebook": {
+        "type": "Record",
+        "attributes": {
+          "id": {
+            "type": "String"
+          },
+          "name": {
+            "type": "String"
+          },
+          "owner": {
+            "type": "String"
+          },
+          "content": {
+            "type": "String"
+          },
+          "public": {
+            "type": "Boolean"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Whenever the entity or resource callback for the path-specific middleware would fail, we were returning an internal server error.

This is not desirable behavior because when users request a non-existent resource, they shouldn't get a 500. They should get a 4xx error.

I debated whether to impose a 404 here and decided against it, because we can't know for sure the reason why the resource or entities weren't found, or the request is failing for another reason. 


