### PR TITLE
Use req.path instead of req.originalUrl for action matching

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -121,7 +121,7 @@ export class ExpressAuthorizationMiddleware {
     }
     protected getMatchedAction = (req: Request): {status: number, error: string} | SimpleRestAuthMapping => {
         const apiMethod = req.method.toLowerCase() as ApiHttpMethod;
-        const currentUrl = req.originalUrl;
+        const currentUrl = req.path;
 
         const actionMatchersForThisVerb = this.expressSpecificMapper[apiMethod];
         
@@ -155,7 +155,7 @@ export class ExpressAuthorizationMiddleware {
     }
     middleware = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         const httpVerb = req.method.toLowerCase();
-        const currentUrl = req.originalUrl;
+        const currentUrl = req.path;
         
         if (shouldBeSkipped(this.config.skippedEndpoints || [], httpVerb, currentUrl)) {
             next();

--- a/tests/unit/actionMatching.test.ts
+++ b/tests/unit/actionMatching.test.ts
@@ -1,0 +1,100 @@
+import { CedarInlineAuthorizationEngine, ExpressAuthorizationMiddleware } from '../../src';
+import { StringifiedSchema } from '@cedar-policy/cedar-authorization';
+import express from 'express';
+import http from 'http';
+
+const schema: StringifiedSchema = {
+    type: 'jsonString',
+    schema: JSON.stringify({
+        UsersApp: {
+            entityTypes: {
+                User: { shape: { attributes: {}, type: 'Record' } },
+                Application: { shape: { attributes: {}, type: 'Record' } },
+            },
+            actions: {
+                'get /users': {
+                    appliesTo: {
+                        context: { type: 'Record', attributes: {} },
+                        principalTypes: ['User'],
+                        resourceTypes: ['Application'],
+                    },
+                    annotations: { httpVerb: 'get', httpPathTemplate: '/users' },
+                },
+                'get /users/{id}': {
+                    appliesTo: {
+                        context: { type: 'Record', attributes: {} },
+                        principalTypes: ['User'],
+                        resourceTypes: ['Application'],
+                    },
+                    annotations: { httpVerb: 'get', httpPathTemplate: '/users/{id}' },
+                },
+            },
+            annotations: { mappingType: 'SimpleRest' },
+            commonTypes: {},
+        },
+    }),
+};
+
+const cedarAuthorizationEngine = new CedarInlineAuthorizationEngine({
+    schema,
+    staticPolicies: 'permit(principal, action == UsersApp::Action::"get /users/{id}", resource);',
+});
+
+function createApp() {
+    const expressAuthorization = new ExpressAuthorizationMiddleware({
+        schema,
+        authorizationEngine: cedarAuthorizationEngine,
+        principalConfiguration: {
+            type: 'custom',
+            getPrincipalEntity: async () => ({
+                uid: { type: 'UsersApp::User', id: 'testuser' },
+                attrs: {},
+                parents: [],
+            }),
+        },
+    });
+
+    const app = express();
+    app.use(expressAuthorization.middleware);
+    app.get('/users', (_req, res) => res.send('user list'));
+    app.get('/users/:id', (_req, res) => res.send('user detail'));
+    return app;
+}
+
+describe('action matching', () => {
+    let server: http.Server;
+    let baseUrl: string;
+
+    beforeAll(async () => {
+        const app = createApp();
+        server = await new Promise<http.Server>((resolve) => {
+            const s = app.listen(0, () => resolve(s));
+        });
+        const addr = server.address() as { port: number };
+        baseUrl = `http://localhost:${addr.port}`;
+    });
+
+    afterAll(() => {
+        server.close();
+    });
+
+    it('allows a request matching a permitted parameterized action', async () => {
+        const res = await fetch(`${baseUrl}/users/123`);
+        expect(res.status).toBe(200);
+    });
+
+    it('denies a request with no matching permit policy', async () => {
+        const res = await fetch(`${baseUrl}/users`);
+        expect(res.status).toBe(401);
+    });
+
+    it('matches actions using the path only, ignoring query strings', async () => {
+        const res = await fetch(`${baseUrl}/users/?x=1`);
+        expect(res.status).toBe(401);
+    });
+
+    it('matches actions using the path only, ignoring multiple query parameters', async () => {
+        const res = await fetch(`${baseUrl}/users/?x=1&y=2`);
+        expect(res.status).toBe(401);
+    });
+});


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
  `getMatchedAction()` and the middleware were using `req.originalUrl` for action
  matching.                                                                      
  `req.path` is more appropriate here as it contains only the path component.    
                                                                                 
All unit tests pass.
